### PR TITLE
Set access token in header for userinfo route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# docker-compose up --build
+# docker compose up --build
 # docker buildx bake --set "*.platform=linux/amd64" --load
 version: "2.4"
 services:

--- a/pam-oidc/Cargo.toml
+++ b/pam-oidc/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "pam-oidc"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["guzman-raphael <raphael.h.guzman@gmail.com>"]
+edition = "2021"
 
 [dependencies]
 yaml-rust = "0.4.5"

--- a/pam-oidc/src/lib.rs
+++ b/pam-oidc/src/lib.rs
@@ -179,11 +179,13 @@ impl PamServiceModule for PamCustom {
         debug!("assigned_scopes: {}", assigned_scopes);
         // Verify token
         info!("Verifying token.");
-        let userinfo_url = format!("{}?access_token={}",
-                                   config[0]["url.userinfo"].as_str().unwrap(),
-                                   access_token);
-        debug!("userinfo_url: {}", userinfo_url);
-        let body = reqwest::blocking::get(&userinfo_url).unwrap().text().unwrap();
+        let body = reqwest::blocking::Client::new()
+            .get(config[0]["url.userinfo"].as_str().unwrap())
+            .header("Authorization", format!("Bearer {}", access_token))
+            .send()
+            .unwrap()
+            .text()
+            .unwrap();
         debug!("body: {}", body);
         let json: Value = serde_json::from_str(&body).unwrap();
         debug!("token's user: {:?}", json.get("sub"));

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,19 +5,20 @@
 
 mariadb() {
     set -e
+    ROOT_PASSWORD=simple
     docker rm -f database
-    docker run --name database -p 3306:3306 -de MYSQL_ROOT_PASSWORD=simple mariadb:10.7 # does not work with latest and non-v1
-    until docker exec -it database mysql -h 127.0.0.1 -uroot -psimple -e "SELECT 1;" 1>/dev/null
+    docker run --name database -de MYSQL_ROOT_PASSWORD=${ROOT_PASSWORD} mariadb:10.7 # does not work with latest and non-v1
+    until docker exec -it database mysql -h 127.0.0.1 -uroot -p${ROOT_PASSWORD} -e "SELECT 1;" 1>/dev/null
     do
         echo waiting...
         sleep 5
     done
-    docker exec -it database mysql -uroot -psimple -e "INSTALL SONAME 'auth_pam_v1';"
-    docker cp /home/rguzman/Downloads/oidc database:/etc/pam.d/oidc
-    docker cp /github/pam-oauth2/pam-oidc/target/debug/libpam_oidc.so database:/lib/x86_64-linux-gnu/security/libpam_oidc.so
+    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "INSTALL SONAME 'auth_pam_v1';"
+    docker cp ./config/service_example database:/etc/pam.d/oidc
+    docker cp ./pam-oidc/target/debug/libpam_oidc.so database:/lib/x86_64-linux-gnu/security/libpam_oidc.so
     docker exec -it database mkdir /etc/datajoint
-    docker cp /home/rguzman/Downloads/libpam_oidc.yaml database:/etc/datajoint/
-    docker exec -it database mysql -uroot -psimple -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED VIA pam USING 'oidc';"
+    docker cp ./config/libpam_oidc.yaml database:/etc/datajoint/
+    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED VIA pam USING 'oidc';"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -pdeny -e "SELECT 'delegated to oidc' as login;"
@@ -25,19 +26,19 @@ mariadb() {
 
 percona() {
     set -e
+    ROOT_PASSWORD=simple
     docker rm -f database
-    docker run --name database -p 3306:3306 -de MYSQL_ROOT_PASSWORD=simple percona:8
-    until docker exec -it database mysql -h 127.0.0.1 -uroot -psimple -e "SELECT 1;" 1>/dev/null
+    docker run --name database -de MYSQL_ROOT_PASSWORD=${ROOT_PASSWORD} --entrypoint bash percona:8 -c "echo 'plugin_load_add = auth_pam.so' >> /etc/my.cnf && /docker-entrypoint.sh mysqld"
+    until docker exec -it database mysql -h 127.0.0.1 -uroot -p${ROOT_PASSWORD} -e "SELECT 1;" 1>/dev/null
     do
         echo waiting...
         sleep 5
     done
-    docker exec -it database mysql -uroot -psimple -e "INSTALL PLUGIN auth_pam SONAME 'auth_pam.so';"
-    docker cp /home/rguzman/Downloads/oidc database:/etc/pam.d/mysqld
-    docker cp /github/pam-oauth2/pam-oidc/target/debug/libpam_oidc.so database:/usr/lib64/security/libpam_oidc.so
+    docker cp ./config/service_example database:/etc/pam.d/oidc
+    docker cp ./pam-oidc/target/debug/libpam_oidc.so database:/usr/lib64/security/libpam_oidc.so
     docker exec -itu root database mkdir /etc/datajoint
-    docker cp /home/rguzman/Downloads/libpam_oidc.yaml database:/etc/datajoint/
-    docker exec -it database mysql -uroot -psimple -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED WITH auth_pam;"
+    docker cp ./config/libpam_oidc.yaml database:/etc/datajoint/
+    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED WITH auth_pam AS 'oidc';"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
     docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -pdeny -e "SELECT 'delegated to oidc' as login;"


### PR DESCRIPTION
This PR addresses the following:
- Use header method to specify `access_token` for userinfo endpoint since Keycloak does not support query parameter method. This approach seems to be more broadly accepted.
- Update tests to be more general/portable for others to run and validate.
- Upgrades rust edition to support `async` `await` functionality (not currently used)