### PR TITLE
DEV-421: Debug error message

### DIFF
--- a/config/mysql-any-password
+++ b/config/mysql-any-password
@@ -1,0 +1,3 @@
+#%PAM-1.0
+auth        required    pam_permit.so
+#account     required    pam_permit.so

--- a/config/service_example
+++ b/config/service_example
@@ -1,2 +1,2 @@
-auth sufficient libpam_oidc.so /etc/datajoint/libpam_oidc.yaml
-account optional libpam_oidc.so
+auth required libpam_oidc.so /etc/datajoint/libpam_oidc.yaml
+account optional libpam_oidc.so /etc/datajoint/libpam_oidc.yaml

--- a/docker/builder.dockerfile
+++ b/docker/builder.dockerfile
@@ -8,12 +8,18 @@ RUN \
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /tmp/pam-oauth2
 COPY pam-oidc /tmp/pam-oauth2/pam-oidc
+# RUN \
+# 	cd pam-oidc && \
+# 	rustup target add x86_64-unknown-linux-gnu && \
+# 	rustup target add x86_64-unknown-linux-musl && \
+# 	rustup show && \
+# 	cargo build --release --target x86_64-unknown-linux-musl && \
+# 	cargo build --release --target x86_64-unknown-linux-gnu && \
+# 	cp target/x86_64-unknown-linux-musl/release/libpam_oidc.so /tmp/pam-oauth2/libpam_oidc_musl.so && \
+# 	cp target/x86_64-unknown-linux-gnu/release/libpam_oidc.so /tmp/pam-oauth2/libpam_oidc_gnu.so
 RUN \
 	cd pam-oidc && \
 	rustup target add x86_64-unknown-linux-gnu && \
-	rustup target add x86_64-unknown-linux-musl && \
 	rustup show && \
-	cargo build --release --target x86_64-unknown-linux-musl && \
-	cargo build --release --target x86_64-unknown-linux-gnu && \
-	cp target/x86_64-unknown-linux-musl/release/libpam_oidc.so /tmp/pam-oauth2/libpam_oidc_musl.so && \
-	cp target/x86_64-unknown-linux-gnu/release/libpam_oidc.so /tmp/pam-oauth2/libpam_oidc_gnu.so
+	cargo build --target x86_64-unknown-linux-gnu && \
+	cp target/x86_64-unknown-linux-gnu/debug/libpam_oidc.so /tmp/pam-oauth2/libpam_oidc_gnu.so

--- a/docker/percona.dockerfile
+++ b/docker/percona.dockerfile
@@ -12,8 +12,10 @@ RUN \
 
 # https://www.percona.com/blog/getting-percona-pam-to-work-with-percona-server-its-client-apps/
 RUN \
-	# chgrp mysql /etc/shadow && \
-	# chmod g+r /etc/shadow && \
+	groupadd shadow && \
+	usermod -a -G shadow mysql && \
+	chown root:shadow /etc/shadow && \
+	chmod g+r /etc/shadow && \
 	useradd ap_user && \
 	echo "ap_user:password" | chpasswd
 USER mysql:mysql

--- a/docker/percona.dockerfile
+++ b/docker/percona.dockerfile
@@ -12,8 +12,8 @@ RUN \
 
 # https://www.percona.com/blog/getting-percona-pam-to-work-with-percona-server-its-client-apps/
 RUN \
-	chgrp mysql /etc/shadow && \
-	chmod g+r /etc/shadow && \
+	# chgrp mysql /etc/shadow && \
+	# chmod g+r /etc/shadow && \
 	useradd ap_user && \
 	echo "ap_user:password" | chpasswd
 USER mysql:mysql

--- a/docker/percona.dockerfile
+++ b/docker/percona.dockerfile
@@ -24,4 +24,5 @@ USER mysql:mysql
 COPY --from=builder /tmp/pam-oauth2/libpam_oidc_gnu.so /usr/lib64/security/libpam_oidc.so
 RUN echo 'plugin_load_add = auth_pam.so' >> /etc/my.cnf
 COPY config/pam_unix /etc/pam.d/mysqld
+COPY config/mysql-any-password /etc/pam.d/mysql-any-password
 COPY config/service_example /etc/pam.d/oidc

--- a/pam-oidc/src/lib.rs
+++ b/pam-oidc/src/lib.rs
@@ -148,23 +148,29 @@ impl PamServiceModule for PamCustom {
     }
 
     fn chauthtok(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
+        info!("chauthtok called.");
         PamError::SUCCESS
     }
 
     fn open_session(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
+        info!("open_session called.");
         PamError::SUCCESS
     }
 
     fn close_session(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
+        info!("close_session called.");
         PamError::SUCCESS
     }
 
     fn setcred(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
+        info!("setcred called.");
         PamError::SUCCESS
     }
 
     fn acct_mgmt(_pamh: Pam, _flags: PamFlags, _args: Vec<String>) -> PamError {
+        info!("acct_mgmt called.");
         PamError::SUCCESS
+        // PamError::USER_UNKNOWN
     }
 }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,8 +6,8 @@
 docker compose up --build -d --wait percona
 docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "CREATE USER 'demouser'@'%' IDENTIFIED WITH auth_pam AS 'oidc';"
 docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "SHOW PLUGINS;" | grep auth_pam
-docker compose exec percona mysql -hlocalhost -udemouser -p"$1" -e "SELECT 1;" || echo "Failed to authenticate with real password"
-docker compose exec percona mysql -hlocalhost -udemouser -p'bogus_password' -e "SELECT 1;" || echo "Failed to authenticate for bogus password"
+docker compose exec percona mysql -hlocalhost -udemouser -p"$1" --enable-cleartext-plugin -e "SELECT 1;" || echo "Failed to authenticate with real password"
+docker compose exec percona mysql -hlocalhost -udemouser -p'bogus_password' --enable-cleartext-plugin -e "SELECT 1;" || echo "Failed to authenticate for bogus password"
 sleep 3
 docker compose logs percona
 docker compose down

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,8 +4,7 @@
 # ./tests/test.sh '<demouser_password>'
 
 docker compose up --build -d --wait percona
-docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "CREATE USER 'demouser'@'%' IDENTIFIED WITH auth_pam AS 'oidc';"
-docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "SHOW PLUGINS;" | grep auth_pam
+docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "CREATE USER 'demouser'@'%' IDENTIFIED WITH auth_pam AS 'mysql-any-password';"
 docker compose exec percona mysql -hlocalhost -udemouser -p"$1" --enable-cleartext-plugin -e "SELECT 1;" || echo "Failed to authenticate with real password"
 docker compose exec percona mysql -hlocalhost -udemouser -p'bogus_password' --enable-cleartext-plugin -e "SELECT 1;" || echo "Failed to authenticate for bogus password"
 sleep 3

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,46 +1,13 @@
 #!/bin/bash
 
-# set -a && . .env && ./tests/test.sh mariadb && set +a
-# set -a && . .env && ./tests/test.sh percona && set +a
+# Usage:
+# ./tests/test.sh '<demouser_password>'
 
-mariadb() {
-    set -e
-    ROOT_PASSWORD=simple
-    docker rm -f database
-    docker run --name database -de MYSQL_ROOT_PASSWORD=${ROOT_PASSWORD} mariadb:10.7 # does not work with latest and non-v1
-    until docker exec -it database mysql -h 127.0.0.1 -uroot -p${ROOT_PASSWORD} -e "SELECT 1;" 1>/dev/null
-    do
-        echo waiting...
-        sleep 5
-    done
-    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "INSTALL SONAME 'auth_pam_v1';"
-    docker cp ./config/service_example database:/etc/pam.d/oidc
-    docker cp ./pam-oidc/target/debug/libpam_oidc.so database:/lib/x86_64-linux-gnu/security/libpam_oidc.so
-    docker exec -it database mkdir /etc/datajoint
-    docker cp ./config/libpam_oidc.yaml database:/etc/datajoint/
-    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED VIA pam USING 'oidc';"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -pdeny -e "SELECT 'delegated to oidc' as login;"
-}
-
-percona() {
-    set -e
-    ROOT_PASSWORD=simple
-    docker rm -f database
-    docker run --name database -de MYSQL_ROOT_PASSWORD=${ROOT_PASSWORD} --entrypoint bash percona:8 -c "echo 'plugin_load_add = auth_pam.so' >> /etc/my.cnf && /docker-entrypoint.sh mysqld"
-    until docker exec -it database mysql -h 127.0.0.1 -uroot -p${ROOT_PASSWORD} -e "SELECT 1;" 1>/dev/null
-    do
-        echo waiting...
-        sleep 5
-    done
-    docker cp ./config/service_example database:/etc/pam.d/oidc
-    docker cp ./pam-oidc/target/debug/libpam_oidc.so database:/usr/lib64/security/libpam_oidc.so
-    docker exec -itu root database mkdir /etc/datajoint
-    docker cp ./config/libpam_oidc.yaml database:/etc/datajoint/
-    docker exec -it database mysql -uroot -p${ROOT_PASSWORD} -e "CREATE USER '${DJ_AUTH_USER}'@'%' IDENTIFIED WITH auth_pam AS 'oidc';"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -p${DJ_AUTH_PASSWORD} -e "SELECT 'delegated to oidc' as login;"
-    docker exec -it database mysql -h 127.0.0.1 -u${DJ_AUTH_USER} -pdeny -e "SELECT 'delegated to oidc' as login;"
-}
-
+docker compose up --build -d --wait percona
+docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "CREATE USER 'demouser'@'%' IDENTIFIED WITH auth_pam AS 'oidc';"
+docker compose exec percona mysql -hlocalhost -uroot -ppassword -e "SHOW PLUGINS;" | grep auth_pam
+docker compose exec percona mysql -hlocalhost -udemouser -p"$1" -e "SELECT 1;" || echo "Failed to authenticate with real password"
+docker compose exec percona mysql -hlocalhost -udemouser -p'bogus_password' -e "SELECT 1;" || echo "Failed to authenticate for bogus password"
+sleep 3
+docker compose logs percona
+docker compose down


### PR DESCRIPTION
Mirror of https://datajoint.atlassian.net/browse/DEV-421

Error message observed in prod Percona when using this plugin:

```
{"log":"2024-01-18T18:53:14.544917Z 908 [ERROR] [MY-000000] [Server] Plugin auth_pam reported: 'Unable to obtain the passwd entry for the user 'ioc-user'.'\n","file":"/var/lib/mysql/mysqld-error.log"}
```

~~The cause of this error message is that the user running `mysqld` does not read access to `/etc/shadow`, as explained in [MariaDB PAM docs](https://mariadb.com/kb/en/authentication-plugin-pam/#configuring-the-pam_unix-pam-module). This is reproducible using the [MySQL tests](https://github.com/datajoint-company/pam-oauth2/tree/master?tab=readme-ov-file#3-mysql-tests) on [880d0f7](https://github.com/datajoint-company/pam-oauth2/pull/15/commits/880d0f7e1979742584531c0789e01cda2d4d37e2)~~. _UPDATE_: this is confirmed not to fix the issue.

```console
$ docker compse logs -f percona
pam-oauth2-percona  | [2024-02-14 18:47:15.374][pam-oidc][0.1.5][INFO][4249257301]: Auth detected. Proceeding...
pam-oauth2-percona  | [2024-02-14 18:47:15.375][pam-oidc][0.1.5][INFO][4249257301]: Inputs read.
pam-oauth2-percona  | [2024-02-14 18:47:15.375][pam-oidc][0.1.5][INFO][4249257301]: Check as password.
pam-oauth2-percona  | [2024-02-14 18:47:15.631][pam-oidc][0.1.5][INFO][4249257301]: Verifying token.
pam-oauth2-percona  | [2024-02-14 18:47:15.841][pam-oidc][0.1.5][INFO][4249257301]: Auth success!
pam-oauth2-percona  | 2024-02-14T18:47:15.844550Z 11 [ERROR] [MY-000000] [Server] Plugin auth_pam reported: 'Unable to obtain the passwd entry for the user 'demouser'.'
```

## Fix

~~The proposed fix is to grant `+r /etc/shadow` permissions to the user running `mysqld` in the production DB. The [MariaDB PAM docs](https://mariadb.com/kb/en/authentication-plugin-pam/#configuring-the-pam_unix-pam-module) explain how to do this if this user is `mysql`.~~ Did not fix, see below.